### PR TITLE
feat: adicionar dependência pwm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ pico_enable_stdio_usb(tarefa1_gpio_embarcatech 1)
 
 # Add the standard library to the build
 target_link_libraries(tarefa1_gpio_embarcatech
-        pico_stdlib)
+        pico_stdlib hardware_pwm) 
 
 # Add the standard include files to the build
 target_include_directories(tarefa1_gpio_embarcatech PRIVATE


### PR DESCRIPTION
Para compilar o código, foi necessário incluir o hardware_pwm no CMake do arquivo.